### PR TITLE
Ip block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Gemfile*
 *.gem
 tags
 .byebug_history
+.rspec_status

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+t/
+Gemfile*
+*.gem
+tags

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ t/
 Gemfile*
 *.gem
 tags
+.byebug_history

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ response = zones.first.firewall_rules.post(data.to_json, content_type: 'applicat
 
 Released under the MIT license.
 
-Copyright, 2012, 2014, by [Marcin Prokop](https://github.com/b4k3r).  
+Copyright, 2012, 2014, by [Marcin Prokop](https://github.com/b4k3r).	
 Copyright, 2017, by [Samuel G. D. Williams](http://www.codeotaku.com/samuel-williams).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ response = zones.first.firewall_rules.post(data.to_json, content_type: 'applicat
 
 Released under the MIT license.
 
-Copyright, 2012, 2014, by [Marcin Prokop](https://github.com/b4k3r).	
+Copyright, 2012, 2014, by [Marcin Prokop](https://github.com/b4k3r).
 Copyright, 2017, by [Samuel G. D. Williams](http://www.codeotaku.com/samuel-williams).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -66,6 +66,29 @@ puts records.first.record[:name]
 puts records
 ```
 
+Get firewall rules:
+
+``` ruby
+all_rules =  zones.first.firewall_rules.all
+block_rules = zones.first.firewall_rules.all("block")  # or "whitelist" or "challenge"
+```
+
+Get blocked ips:
+
+``` ruby
+block_rules = zones.first.firewall_rules.all("block") 
+blocked_ips = zones.first.firewall_rules.firewalled_ips(block_rules)
+```
+
+Block an ip:
+
+``` ruby
+# ip = "nnn.nnn.nnn.nnn"
+# note: "some note about the block"
+data = {"mode":"block","configuration":{"target":"ip","value":"#{ip}"},"notes":"#{note} #{Time.now.strftime("%m/%d/%y")} "}
+response = zones.first.firewall_rules.post(data.to_json, content_type: 'application/json')
+
+```
 ## Contributing
 
 1. Fork it
@@ -103,3 +126,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+
+

--- a/cloudflare.gemspec
+++ b/cloudflare.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.6"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "byebug"
 end

--- a/cloudflare.gemspec
+++ b/cloudflare.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.6"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "byebug"
 end

--- a/lib/cloudflare/connection.rb
+++ b/lib/cloudflare/connection.rb
@@ -29,27 +29,44 @@ require_relative 'response'
 module Cloudflare
 	DEFAULT_URL = "https://api.cloudflare.com/client/v4/"
 	TIMEOUT = 10 # Default is 5 seconds
-	
+
 	class Resource < RestClient::Resource
+    include Enumerable
 		# @param api_key [String] `X-Auth-Key` or `X-Auth-User-Service-Key` if no email provided.
 		# @param email [String] `X-Auth-Email`, your email address for the account.
 		def initialize(url = DEFAULT_URL, key: nil, email: nil, **options)
 			headers = options[:headers] || {}
-			
+
 			if email.nil?
 				headers['X-Auth-User-Service-Key'] = key
 			else
 				headers['X-Auth-Key'] = key
 				headers['X-Auth-Email'] = email
 			end
-			
+
 			# Convert HTTP API responses to our own internal response class:
 			super(url, headers: headers, accept: 'application/json', **options) do |response|
 				Response.new(response.request.url, response.body)
 			end
 		end
+
+    def paginate(obj, url, url_args = "")
+			page = 1
+			page_size = 100
+			results = []
+
+			loop do  # fetch and aggregate all pages
+				rules = obj.new(concat_urls(url, "?scope_type=organization#{url_args}&per_page=#{page_size}&page=#{page}"), self, **options)
+				results += rules.get.results
+				break if results.size % page_size != 0
+				page += 1
+			end
+			results
 	end
-	
+
+
+	end
+
 	class Connection < Resource
 	end
 end

--- a/lib/cloudflare/connection.rb
+++ b/lib/cloudflare/connection.rb
@@ -27,29 +27,29 @@ require 'rest-client'
 require_relative 'response'
 
 module Cloudflare
-  DEFAULT_URL = "https://api.cloudflare.com/client/v4/"
-  TIMEOUT = 10 # Default is 5 seconds
+	DEFAULT_URL = "https://api.cloudflare.com/client/v4/"
+	TIMEOUT = 10 # Default is 5 seconds
 
-  class Resource < RestClient::Resource
-    # @param api_key [String] `X-Auth-Key` or `X-Auth-User-Service-Key` if no email provided.
-    # @param email [String] `X-Auth-Email`, your email address for the account.
-    def initialize(url = DEFAULT_URL, key: nil, email: nil, **options)
-      headers = options[:headers] || {}
+	class Resource < RestClient::Resource
+		# @param api_key [String] `X-Auth-Key` or `X-Auth-User-Service-Key` if no email provided.
+		# @param email [String] `X-Auth-Email`, your email address for the account.
+		def initialize(url = DEFAULT_URL, key: nil, email: nil, **options)
+			headers = options[:headers] || {}
 
-      if email.nil?
-        headers['X-Auth-User-Service-Key'] = key
-      else
-        headers['X-Auth-Key'] = key
-        headers['X-Auth-Email'] = email
-      end
+			if email.nil?
+				headers['X-Auth-User-Service-Key'] = key
+			else
+				headers['X-Auth-Key'] = key
+				headers['X-Auth-Email'] = email
+			end
 
-      # Convert HTTP API responses to our own internal response class:
-      super(url, headers: headers, accept: 'application/json', **options) do |response|
-        Response.new(response.request.url, response.body)
-      end
-    end
-  end
+			# Convert HTTP API responses to our own internal response class:
+			super(url, headers: headers, accept: 'application/json', **options) do |response|
+				Response.new(response.request.url, response.body)
+			end
+		end
+	end
 
-  class Connection < Resource
-  end
+	class Connection < Resource
+	end
 end

--- a/lib/cloudflare/connection.rb
+++ b/lib/cloudflare/connection.rb
@@ -27,29 +27,29 @@ require 'rest-client'
 require_relative 'response'
 
 module Cloudflare
-	DEFAULT_URL = "https://api.cloudflare.com/client/v4/"
-	TIMEOUT = 10 # Default is 5 seconds
-	
-	class Resource < RestClient::Resource
-		# @param api_key [String] `X-Auth-Key` or `X-Auth-User-Service-Key` if no email provided.
-		# @param email [String] `X-Auth-Email`, your email address for the account.
-		def initialize(url = DEFAULT_URL, key: nil, email: nil, **options)
-			headers = options[:headers] || {}
-			
-			if email.nil?
-				headers['X-Auth-User-Service-Key'] = key
-			else
-				headers['X-Auth-Key'] = key
-				headers['X-Auth-Email'] = email
-			end
-			
-			# Convert HTTP API responses to our own internal response class:
-			super(url, headers: headers, accept: 'application/json', **options) do |response|
-				Response.new(response.request.url, response.body)
-			end
-		end
-	end
-	
-	class Connection < Resource
-	end
+  DEFAULT_URL = "https://api.cloudflare.com/client/v4/"
+  TIMEOUT = 10 # Default is 5 seconds
+
+  class Resource < RestClient::Resource
+    # @param api_key [String] `X-Auth-Key` or `X-Auth-User-Service-Key` if no email provided.
+    # @param email [String] `X-Auth-Email`, your email address for the account.
+    def initialize(url = DEFAULT_URL, key: nil, email: nil, **options)
+      headers = options[:headers] || {}
+
+      if email.nil?
+        headers['X-Auth-User-Service-Key'] = key
+      else
+        headers['X-Auth-Key'] = key
+        headers['X-Auth-Email'] = email
+      end
+
+      # Convert HTTP API responses to our own internal response class:
+      super(url, headers: headers, accept: 'application/json', **options) do |response|
+        Response.new(response.request.url, response.body)
+      end
+    end
+  end
+
+  class Connection < Resource
+  end
 end

--- a/lib/cloudflare/connection.rb
+++ b/lib/cloudflare/connection.rb
@@ -29,27 +29,27 @@ require_relative 'response'
 module Cloudflare
 	DEFAULT_URL = "https://api.cloudflare.com/client/v4/"
 	TIMEOUT = 10 # Default is 5 seconds
-
+	
 	class Resource < RestClient::Resource
 		# @param api_key [String] `X-Auth-Key` or `X-Auth-User-Service-Key` if no email provided.
 		# @param email [String] `X-Auth-Email`, your email address for the account.
 		def initialize(url = DEFAULT_URL, key: nil, email: nil, **options)
 			headers = options[:headers] || {}
-
+			
 			if email.nil?
 				headers['X-Auth-User-Service-Key'] = key
 			else
 				headers['X-Auth-Key'] = key
 				headers['X-Auth-Email'] = email
 			end
-
+			
 			# Convert HTTP API responses to our own internal response class:
 			super(url, headers: headers, accept: 'application/json', **options) do |response|
 				Response.new(response.request.url, response.body)
 			end
 		end
 	end
-
+	
 	class Connection < Resource
 	end
 end

--- a/lib/cloudflare/version.rb
+++ b/lib/cloudflare/version.rb
@@ -20,5 +20,5 @@
 # THE SOFTWARE.
 
 module Cloudflare
-	VERSION = '3.0.0'
+  VERSION = '3.0.2'
 end

--- a/lib/cloudflare/version.rb
+++ b/lib/cloudflare/version.rb
@@ -20,5 +20,5 @@
 # THE SOFTWARE.
 
 module Cloudflare
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 end

--- a/lib/cloudflare/version.rb
+++ b/lib/cloudflare/version.rb
@@ -20,5 +20,5 @@
 # THE SOFTWARE.
 
 module Cloudflare
-  VERSION = '3.1.1'
+  VERSION = '3.1.2'
 end

--- a/lib/cloudflare/version.rb
+++ b/lib/cloudflare/version.rb
@@ -20,5 +20,5 @@
 # THE SOFTWARE.
 
 module Cloudflare
-  VERSION = '3.0.4'
+  VERSION = '3.1.0'
 end

--- a/lib/cloudflare/version.rb
+++ b/lib/cloudflare/version.rb
@@ -20,5 +20,5 @@
 # THE SOFTWARE.
 
 module Cloudflare
-  VERSION = '3.0.3'
+  VERSION = '3.0.4'
 end

--- a/lib/cloudflare/version.rb
+++ b/lib/cloudflare/version.rb
@@ -20,5 +20,5 @@
 # THE SOFTWARE.
 
 module Cloudflare
-  VERSION = '3.0.2'
+  VERSION = '3.0.3'
 end

--- a/lib/cloudflare/version.rb
+++ b/lib/cloudflare/version.rb
@@ -20,5 +20,5 @@
 # THE SOFTWARE.
 
 module Cloudflare
-  VERSION = '3.1.2'
+  VERSION = '3.1.3'
 end

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -22,6 +22,7 @@
 # added firewall rules support: david rosenbloom|davidr@artifactory.com|artifactory
 #
 require_relative 'connection'
+
 module Cloudflare
 	class Connection < Resource
 		def zones
@@ -121,7 +122,7 @@ module Cloudflare
 
 		def validate_rules_filters(mode, ip)
 			raise "Bad mode arg: #{mode}" if mode and !['block', 'whitelist', 'challenge'].include?(mode)
-			raise "Bad ip arg: #{ip}" if ip and !(ip =~ /[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*/)		 # TODO: add ranges, e.g. /24
+			raise "Bad ip arg: #{ip}" if ip and !IPAddr.new(ip).ipv4?
 		end
 
 	end
@@ -156,7 +157,7 @@ module Cloudflare
 		def find_by_name(name)
 
 			response = self.get(params: {name: name})
-			
+
 
 			unless response.empty?
 				record = response.results.first

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -60,20 +60,8 @@ module Cloudflare
 		attr :zone
 
 		def all
-			dns_url = "?scope_type=organization"
-			page = 1
-			page_size = 100
-			results = []
-
-			loop do  # fetch and aggregate all pages
-				rules = DNSRecords.new(concat_urls(url, "#{dns_url}&per_page=#{page_size}&page=#{page}"), self, **options)
-				results += rules.get.results
-				break if results.size % page_size != 0
-				page += 1
-			end
-
+			results = paginate(DNSRecords, url)
 			results.map{|record| DNSRecord.new(concat_urls(url, record[:id]), record, **options)}
-
 		end
 
 		def find_by_name(name)
@@ -115,21 +103,12 @@ module Cloudflare
 		attr :zone
 
 		def all(mode = nil, ip = nil, notes = nil)
-			fw_url = "?scope_type=organization"
-			fw_url.concat("&mode=#{mode}") if mode
-			fw_url.concat("&configuration_value=#{ip}") if ip
-			fw_url.concat("&notes=#{notes}") if notes
-			page = 1
-			page_size = 100
-			results = []
+			url_args = ""
+			url_args.concat("&mode=#{mode}") if mode
+			url_args.concat("&configuration_value=#{ip}") if ip
+			url_args.concat("&notes=#{notes}") if notes
 
-			loop do  # fetch and aggregate all pages
-				rules = FirewallRules.new(concat_urls(url, "#{fw_url}&per_page=#{page_size}&page=#{page}"), self, **options)
-				results += rules.get.results
-				break if results.size % page_size != 0
-				page += 1
-			end
-
+			results = paginate(FirewallRules, url, url_args)
 			results.map{|record| FirewallRule.new(concat_urls(url, record[:id]), record, **options)}
 		end
 

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -73,7 +73,6 @@ module Cloudflare
 
 	class FirewallRule < Resource
 		def initialize(url, record = nil, **options)
-			# 0 - Rule init
 			super(url, **options)
 
 			@record = record || self.get.result

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -22,7 +22,6 @@
 # added firewall rules support: david rosenbloom|davidr@artifactory.com|artifactory
 #
 require_relative 'connection'
-require 'byebug'
 module Cloudflare
   class Connection < Resource
     def zones

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -54,7 +54,6 @@ module Cloudflare
 		attr :zone
 
 		def all
-			# self.get.results.map{|record| DNSRecord.new(concat_urls(url, record[:id]), record, **options)}
 			dns_url = "?scope_type=organization"
 			page = 1
 			page_size = 100

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -34,7 +34,12 @@ module Cloudflare
 			
 			@record = record || self.get.result
 		end
-		
+
+		def update_content(content)
+			response = self.put({type: @record[:type], name: @record[:name], content: content}.to_json, content_type: 'application/json')
+			response.successful?
+		end
+
 		attr :record
 		
 		def to_s

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -88,8 +88,6 @@ module Cloudflare
 
 	class FirewallRules < Resource
 		def initialize(url, zone, **options)
-			# 1 - Rules init
-			# byebug
 			super(url, **options)
 
 			@zone = zone

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -24,150 +24,170 @@
 require_relative 'connection'
 
 module Cloudflare
-	class Connection < Resource
-		def zones
-			@zones ||= Zones.new(concat_urls(url, 'zones'), options)
-		end
-	end
+  class Connection < Resource
+    def zones
+      @zones ||= Zones.new(concat_urls(url, 'zones'), options)
+    end
+  end
 
-	class DNSRecord < Resource
-		def initialize(url, record = nil, **options)
-			super(url, **options)
+  class DNSRecord < Resource
+    def initialize(url, record = nil, **options)
+      super(url, **options)
 
-			@record = record || self.get.result
-		end
+      @record = record || self.get.result
+    end
 
-		attr :record
+    attr :record
 
-		def to_s
-			"#{@record[:name]} #{@record[:type]} #{@record[:content]}"
-		end
-	end
+    def to_s
+      "#{@record[:name]} #{@record[:type]} #{@record[:content]}"
+    end
+  end
 
-	class DNSRecords < Resource
-		def initialize(url, zone, **options)
-			super(url, **options)
+  class DNSRecords < Resource
+    def initialize(url, zone, **options)
+      super(url, **options)
 
-			@zone = zone
-		end
+      @zone = zone
+    end
 
-		attr :zone
+    attr :zone
 
-		def all
-			self.get.results.map{|record| DNSRecord.new(concat_urls(url, record[:id]), record, **options)}
-		end
+    def all
+      self.get.results.map{|record| DNSRecord.new(concat_urls(url, record[:id]), record, **options)}
+    end
 
-		def find_by_name(name)
-			response = self.get(params: {name: name})
+    def find_by_name(name)
+      response = self.get(params: {name: name})
 
-			unless response.empty?
-				record = response.results.first
+      unless response.empty?
+        record = response.results.first
 
-				DNSRecord.new(concat_urls(url, record[:id]), record, **options)
-			end
-		end
+        DNSRecord.new(concat_urls(url, record[:id]), record, **options)
+      end
+    end
 
-		def find_by_id(id)
-			DNSRecord.new(concat_urls(url, id), **options)
-		end
-	end
+    def find_by_id(id)
+      DNSRecord.new(concat_urls(url, id), **options)
+    end
+  end
 
-	class FirewallRule < Resource
-		def initialize(url, record = nil, **options)
-			super(url, **options)
+  class FirewallRule < Resource
+    def initialize(url, record = nil, **options)
+      super(url, **options)
 
-			@record = record || self.get.result
-		end
+      @record = record || self.get.result
+    end
 
-		attr :record
+    attr :record
 
-		def to_s
-			"#{@record[:configuration][:value]} - #{@record[:mode]} - #{@record[:notes]}"
-		end
-	end
+    def to_s
+      "#{@record[:configuration][:value]} - #{@record[:mode]} - #{@record[:notes]}"
+    end
+  end
 
-	class FirewallRules < Resource
-		def initialize(url, zone, **options)
-			super(url, **options)
+  class FirewallRules < Resource
+    def initialize(url, zone, **options)
+      super(url, **options)
 
-			@zone = zone
-		end
+      @zone = zone
+    end
 
-		attr :zone
+    attr :zone
 
-		def all(mode = nil, ip = nil, notes = nil)
-			# although this is within the resource, the initialized resource is not leveraged; rather, new resource instances are created to fetch paginated data.
-			validate_rules_filters(mode, ip)
-			fw_url ="firewall/access_rules/rules?scope_type=organization"
-			fw_url.concat("&mode=#{mode}") if mode
-			fw_url.concat("&configuration_value=#{ip}") if ip
-			fw_url.concat("&notes=#{notes}") if notes
-			page = 1
-			page_size = 100
-			results = []
+    def all(mode = nil, ip = nil, notes = nil)
+      # although this is within the resource, the initialized resource is not leveraged; rather, new resource instances are created to fetch paginated data.
+      validate_rules_filters(mode, ip)
+      fw_url ="firewall/access_rules/rules?scope_type=organization"
+      fw_url.concat("&mode=#{mode}") if mode
+      fw_url.concat("&configuration_value=#{ip}") if ip
+      fw_url.concat("&notes=#{notes}") if notes
+      page = 1
+      page_size = 100
+      results = []
 
-			loop do  # fetch and aggregate all pages
-				rules = FirewallRules.new(concat_urls(url, "#{fw_url}&per_page=#{page_size}&page=#{page}"), self, **options)
-				results += rules.get.results
-				break if results.size % page_size != 0
-				page += 1
-			end
+      loop do  # fetch and aggregate all pages
+        rules = FirewallRules.new(concat_urls(url, "#{fw_url}&per_page=#{page_size}&page=#{page}"), self, **options)
+        results += rules.get.results
+        break if results.size % page_size != 0
+        page += 1
+      end
 
-			results.map{|record| FirewallRule.new(concat_urls(url, record[:id]), record, **options)}
-		end
+      results.map{|record| FirewallRule.new(concat_urls(url, record[:id]), record, **options)}
+    end
 
-		def firewalled_ips(rules)
-			rules.collect {|r| r.record[:configuration][:value]}
-		end
+    def firewalled_ips(rules)
+      rules.collect {|r| r.record[:configuration][:value]}
+    end
 
-		def validate_rules_filters(mode, ip)
-			raise "Bad mode arg: #{mode}" if mode and !['block', 'whitelist', 'challenge'].include?(mode)
-			raise "Bad ip arg: #{ip}" if ip and !IPAddr.new(ip).ipv4?
-		end
+    def validate_rules_filters(mode, ip)
+      raise "Bad mode arg: #{mode}" if mode and !['block', 'whitelist', 'challenge'].include?(mode)
+      raise "Bad ip arg: #{ip}" if ip and !IPAddr.new(ip).ipv4?
+    end
 
-	end
+    def blocked_ips
+      firewalled_ips(all("block"))
+    end
 
-	class Zone < Resource
-		def initialize(url, record = nil, **options)
-			# byebug
-			super(url, **options)
-			@record = record || self.get.result
-		end
+    def set(mode, ip, note)
+      data = {"mode":"#{mode}","configuration":{"target":"ip","value":"#{ip}"},"notes":"cloudflare gem firewall_rules [#{mode}] #{note} #{Time.now.strftime("%m/%d/%y")} "}
+      post(data.to_json, content_type: 'application/json')
+    end
 
-		attr :record
+    def unset(record)
+      puts self.url
+      puts record.inspect
+      rule = find_by_id(record[:id])
+      rule.delete
+    end
 
-		def dns_records
-			@dns_records ||= DNSRecords.new(concat_urls(url, 'dns_records'), self, **options)
-		end
+    def find_by_id(id)
+      FirewallRule.new(concat_urls(url, id), **options)
+    end
+  end
 
-		def firewall_rules
-			@firewall_rules ||= FirewallRules.new(concat_urls(url, "firewall/access_rules/rules?scope_type=organization"), self, **options)
-		end
+  class Zone < Resource
+    def initialize(url, record = nil, **options)
+      # byebug
+      super(url, **options)
+      @record = record || self.get.result
+    end
 
-		def to_s
-			@record[:name]
-		end
-	end
+    attr :record
 
-	class Zones < Resource
-		def all
-			self.get.results.map{|record| Zone.new(concat_urls(url, record[:id]), record, **options)}
-		end
+    def dns_records
+      @dns_records ||= DNSRecords.new(concat_urls(url, 'dns_records'), self, **options)
+    end
 
-		def find_by_name(name)
+    def firewall_rules
+      # @firewall_rules ||= FirewallRules.new(concat_urls(url, "firewall/access_rules/rules?scope_type=organization"), self, **options)
+      @firewall_rules ||= FirewallRules.new(concat_urls(url, "firewall/access_rules/rules"), self, **options)
+    end
 
-			response = self.get(params: {name: name})
+    def to_s
+      @record[:name]
+    end
+  end
+
+  class Zones < Resource
+    def all
+      self.get.results.map{|record| Zone.new(concat_urls(url, record[:id]), record, **options)}
+    end
+
+    def find_by_name(name)
+
+      response = self.get(params: {name: name})
 
 
-			unless response.empty?
-				record = response.results.first
+      unless response.empty?
+        record = response.results.first
 
-				Zone.new(concat_urls(url, record[:id]), record, **options)
-			end
-		end
+        Zone.new(concat_urls(url, record[:id]), record, **options)
+      end
+    end
 
-		def find_by_id(id)
-			Zone.new(concat_urls(url, id), **options)
-		end
-	end
+    def find_by_id(id)
+      Zone.new(concat_urls(url, id), **options)
+    end
+  end
 end

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -118,6 +118,11 @@ module Cloudflare
       raise "Bad ip arg: #{ip}" if ip and !(ip =~ /[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*/)    # TODO: add ranges, e.g. /24
     end
 
+    def firewall_rules_resource
+      FirewallRules.new(concat_urls(url, "firewall/access_rules/rules?scope_type=organization"), self, **options)
+    end
+
+
     def firewall_rules(mode = nil, ip = nil, notes = nil)
       # 4 - rules request
       validate_args(mode, ip)
@@ -142,7 +147,6 @@ module Cloudflare
     def firewalled_ips(rules)
       rules.collect {|r| r.record[:configuration][:value]}
     end
-
 
     def to_s
       @record[:name]

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -24,151 +24,151 @@
 require_relative 'connection'
 require 'byebug'
 module Cloudflare
-  class Connection < Resource
-    def zones
-      @zones ||= Zones.new(concat_urls(url, 'zones'), options)
-    end
-  end
+	class Connection < Resource
+		def zones
+			@zones ||= Zones.new(concat_urls(url, 'zones'), options)
+		end
+	end
 
-  class DNSRecord < Resource
-    def initialize(url, record = nil, **options)
-      super(url, **options)
+	class DNSRecord < Resource
+		def initialize(url, record = nil, **options)
+			super(url, **options)
 
-      @record = record || self.get.result
-    end
+			@record = record || self.get.result
+		end
 
-    attr :record
+		attr :record
 
-    def to_s
-      "#{@record[:name]} #{@record[:type]} #{@record[:content]}"
-    end
-  end
+		def to_s
+			"#{@record[:name]} #{@record[:type]} #{@record[:content]}"
+		end
+	end
 
-  class DNSRecords < Resource
-    def initialize(url, zone, **options)
-      super(url, **options)
+	class DNSRecords < Resource
+		def initialize(url, zone, **options)
+			super(url, **options)
 
-      @zone = zone
-    end
+			@zone = zone
+		end
 
-    attr :zone
+		attr :zone
 
-    def all
-      self.get.results.map{|record| DNSRecord.new(concat_urls(url, record[:id]), record, **options)}
-    end
+		def all
+			self.get.results.map{|record| DNSRecord.new(concat_urls(url, record[:id]), record, **options)}
+		end
 
-    def find_by_name(name)
-      response = self.get(params: {name: name})
+		def find_by_name(name)
+			response = self.get(params: {name: name})
 
-      unless response.empty?
-        record = response.results.first
+			unless response.empty?
+				record = response.results.first
 
-        DNSRecord.new(concat_urls(url, record[:id]), record, **options)
-      end
-    end
+				DNSRecord.new(concat_urls(url, record[:id]), record, **options)
+			end
+		end
 
-    def find_by_id(id)
-      DNSRecord.new(concat_urls(url, id), **options)
-    end
-  end
+		def find_by_id(id)
+			DNSRecord.new(concat_urls(url, id), **options)
+		end
+	end
 
-  class FirewallRule < Resource
-    def initialize(url, record = nil, **options)
-      # 0 - Rule init
-      super(url, **options)
+	class FirewallRule < Resource
+		def initialize(url, record = nil, **options)
+			# 0 - Rule init
+			super(url, **options)
 
-      @record = record || self.get.result
-    end
+			@record = record || self.get.result
+		end
 
-    attr :record
+		attr :record
 
-    def to_s
-      "#{@record[:configuration][:value]} - #{@record[:mode]} - #{@record[:notes]}"
-    end
-  end
+		def to_s
+			"#{@record[:configuration][:value]} - #{@record[:mode]} - #{@record[:notes]}"
+		end
+	end
 
-  class FirewallRules < Resource
-    def initialize(url, zone, **options)
-      # 1 - Rules init
-      # byebug
-      super(url, **options)
+	class FirewallRules < Resource
+		def initialize(url, zone, **options)
+			# 1 - Rules init
+			# byebug
+			super(url, **options)
 
-      @zone = zone
-    end
+			@zone = zone
+		end
 
-    attr :zone
+		attr :zone
 
-    def all(mode = nil, ip = nil, notes = nil)
-      # although this is within the resource, the initialized resource is not leveraged; rather, new resource instances are created to fetch paginated data.
-      validate_rules_filters(mode, ip)
-      fw_url ="firewall/access_rules/rules?scope_type=organization"
-      fw_url.concat("&mode=#{mode}") if mode
-      fw_url.concat("&configuration_value=#{ip}") if ip
-      fw_url.concat("&notes=#{notes}") if notes
-      page = 1
-      page_size = 100
-      results = []
+		def all(mode = nil, ip = nil, notes = nil)
+			# although this is within the resource, the initialized resource is not leveraged; rather, new resource instances are created to fetch paginated data.
+			validate_rules_filters(mode, ip)
+			fw_url ="firewall/access_rules/rules?scope_type=organization"
+			fw_url.concat("&mode=#{mode}") if mode
+			fw_url.concat("&configuration_value=#{ip}") if ip
+			fw_url.concat("&notes=#{notes}") if notes
+			page = 1
+			page_size = 100
+			results = []
 
-      loop do  # fetch and aggregate all pages
-        rules = FirewallRules.new(concat_urls(url, "#{fw_url}&per_page=#{page_size}&page=#{page}"), self, **options)
-        results += rules.get.results
-        break if results.size % page_size != 0
-        page += 1
-      end
+			loop do  # fetch and aggregate all pages
+				rules = FirewallRules.new(concat_urls(url, "#{fw_url}&per_page=#{page_size}&page=#{page}"), self, **options)
+				results += rules.get.results
+				break if results.size % page_size != 0
+				page += 1
+			end
 
-      results.map{|record| FirewallRule.new(concat_urls(url, record[:id]), record, **options)}
-    end
+			results.map{|record| FirewallRule.new(concat_urls(url, record[:id]), record, **options)}
+		end
 
-    def firewalled_ips(rules)
-      rules.collect {|r| r.record[:configuration][:value]}
-    end
+		def firewalled_ips(rules)
+			rules.collect {|r| r.record[:configuration][:value]}
+		end
 
-    def validate_rules_filters(mode, ip)
-      raise "Bad mode arg: #{mode}" if mode and !['block', 'whitelist', 'challenge'].include?(mode)
-      raise "Bad ip arg: #{ip}" if ip and !(ip =~ /[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*/)    # TODO: add ranges, e.g. /24
-    end
+		def validate_rules_filters(mode, ip)
+			raise "Bad mode arg: #{mode}" if mode and !['block', 'whitelist', 'challenge'].include?(mode)
+			raise "Bad ip arg: #{ip}" if ip and !(ip =~ /[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*/)		 # TODO: add ranges, e.g. /24
+		end
 
-  end
+	end
 
-  class Zone < Resource
-    def initialize(url, record = nil, **options)
-      # byebug
-      super(url, **options)
-      @record = record || self.get.result
-    end
+	class Zone < Resource
+		def initialize(url, record = nil, **options)
+			# byebug
+			super(url, **options)
+			@record = record || self.get.result
+		end
 
-    attr :record
+		attr :record
 
-    def dns_records
-      @dns_records ||= DNSRecords.new(concat_urls(url, 'dns_records'), self, **options)
-    end
+		def dns_records
+			@dns_records ||= DNSRecords.new(concat_urls(url, 'dns_records'), self, **options)
+		end
 
-    def firewall_rules
-      @firewall_rules ||= FirewallRules.new(concat_urls(url, "firewall/access_rules/rules?scope_type=organization"), self, **options)
-    end
+		def firewall_rules
+			@firewall_rules ||= FirewallRules.new(concat_urls(url, "firewall/access_rules/rules?scope_type=organization"), self, **options)
+		end
 
-    def to_s
-      @record[:name]
-    end
-  end
+		def to_s
+			@record[:name]
+		end
+	end
 
-  class Zones < Resource
-    def all
-      self.get.results.map{|record| Zone.new(concat_urls(url, record[:id]), record, **options)}
-    end
+	class Zones < Resource
+		def all
+			self.get.results.map{|record| Zone.new(concat_urls(url, record[:id]), record, **options)}
+		end
 
-    def find_by_name(name)
-      record = self.get(params: {name: name}).result
+		def find_by_name(name)
+			record = self.get(params: {name: name}).result
 
-      unless response.empty?
-        record = response.results.first
+			unless response.empty?
+				record = response.results.first
 
-        Zone.new(concat_urls(url, record[:id]), record, **options)
-      end
-    end
+				Zone.new(concat_urls(url, record[:id]), record, **options)
+			end
+		end
 
-    def find_by_id(id)
-      Zone.new(concat_urls(url, id), **options)
-    end
-  end
+		def find_by_id(id)
+			Zone.new(concat_urls(url, id), **options)
+		end
+	end
 end

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -18,7 +18,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-
+# require 'byebug'
 require_relative 'connection'
 
 module Cloudflare
@@ -94,6 +94,8 @@ module Cloudflare
     attr :zone
 
     def all
+      # byebug
+      # ?scope_type=organization&mode=block&per_page=100&page=#{page}\
       self.get.results.map{|record| WAFAccessRule.new(concat_urls(url, record[:id]), record, **options)}
     end
 
@@ -128,7 +130,7 @@ module Cloudflare
     end
 
     def waf_access_rules
-      @waf_access_rules ||= WAFAccessRules.new(concat_urls(url, 'firewall/access_rules/rules'), self, **options)
+      @waf_access_rules ||= WAFAccessRules.new(concat_urls(url, 'firewall/access_rules/rules?scope_type=organization&mode=block&per_page=100'), self, **options)
     end
 
 

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -22,89 +22,138 @@
 require_relative 'connection'
 
 module Cloudflare
-	class Connection < Resource
-		def zones
-			@zones ||= Zones.new(concat_urls(url, 'zones'), options)
-		end
-	end
-	
-	class DNSRecord < Resource
-		def initialize(url, record = nil, **options)
-			super(url, **options)
-			
-			@record = record || self.get.result
-		end
-		
-		attr :record
-		
-		def to_s
-			"#{@record[:name]} #{@record[:type]} #{@record[:content]}"
-		end
-	end
-	
-	class DNSRecords < Resource
-		def initialize(url, zone, **options)
-			super(url, **options)
-			
-			@zone = zone
-		end
-		
-		attr :zone
-		
-		def all
-			self.get.results.map{|record| DNSRecord.new(concat_urls(url, record[:id]), record, **options)}
-		end
-		
-		def find_by_name(name)
-			response = self.get(params: {name: name})
-			
-			unless response.empty?
-				record = response.results.first
-				
-				DNSRecord.new(concat_urls(url, record[:id]), record, **options)
-			end
-		end
-		
-		def find_by_id(id)
-			DNSRecord.new(concat_urls(url, id), **options)
-		end
-	end
-	
-	class Zone < Resource
-		def initialize(url, record = nil, **options)
-			super(url, **options)
-			
-			@record = record || self.get.result
-		end
-		
-		attr :record
-		
-		def dns_records
-			@dns_records ||= DNSRecords.new(concat_urls(url, 'dns_records'), self, **options)
-		end
-		
-		def to_s
-			@record[:name]
-		end
-	end
-	
-	class Zones < Resource
-		def all
-			self.get.results.map{|record| Zone.new(concat_urls(url, record[:id]), record, **options)}
-		end
-		
-		def find_by_name(name)
-			record = self.get(params: {name: name}).result
-			
-			unless response.empty?
-				record = response.results.first
-				
-				Zone.new(concat_urls(url, record[:id]), record, **options)
-			end
-		end
-		
-		def find_by_id(id)
-			Zone.new(concat_urls(url, id), **options)
-		end
-	end
+  class Connection < Resource
+    def zones
+      @zones ||= Zones.new(concat_urls(url, 'zones'), options)
+    end
+  end
+
+  class DNSRecord < Resource
+    def initialize(url, record = nil, **options)
+      super(url, **options)
+
+      @record = record || self.get.result
+    end
+
+    attr :record
+
+    def to_s
+      "#{@record[:name]} #{@record[:type]} #{@record[:content]}"
+    end
+  end
+
+  class DNSRecords < Resource
+    def initialize(url, zone, **options)
+      super(url, **options)
+
+      @zone = zone
+    end
+
+    attr :zone
+
+    def all
+      self.get.results.map{|record| DNSRecord.new(concat_urls(url, record[:id]), record, **options)}
+    end
+
+    def find_by_name(name)
+      response = self.get(params: {name: name})
+
+      unless response.empty?
+        record = response.results.first
+
+        DNSRecord.new(concat_urls(url, record[:id]), record, **options)
+      end
+    end
+
+    def find_by_id(id)
+      DNSRecord.new(concat_urls(url, id), **options)
+    end
+  end
+#################
+  class WAFAccessRule < Resource
+    def initialize(url, record = nil, **options)
+      super(url, **options)
+
+      @record = record || self.get.result
+    end
+
+    attr :record
+
+    def to_s
+      "#{@record[:name]} #{@record[:type]} #{@record[:content]}"
+    end
+  end
+
+  class WAFAccessRules < Resource
+    def initialize(url, zone, **options)
+      super(url, **options)
+
+      @zone = zone
+    end
+
+    attr :zone
+
+    def all
+      self.get.results.map{|record| WAFAccessRule.new(concat_urls(url, record[:id]), record, **options)}
+    end
+
+    def find_by_name(name)
+      response = self.get(params: {name: name})
+
+      unless response.empty?
+        record = response.results.first
+
+        WAFAccessRule.new(concat_urls(url, record[:id]), record, **options)
+      end
+    end
+
+    def find_by_id(id)
+      WAFAccessRule.new(concat_urls(url, id), **options)
+    end
+  end
+
+
+##################
+  class Zone < Resource
+    def initialize(url, record = nil, **options)
+      super(url, **options)
+
+      @record = record || self.get.result
+    end
+
+    attr :record
+
+    def dns_records
+      @dns_records ||= DNSRecords.new(concat_urls(url, 'dns_records'), self, **options)
+    end
+
+    def waf_access_rules
+      @waf_access_rules ||= WAFAccessRules.new(concat_urls(url, 'firewall/access_rules/rules'), self, **options)
+    end
+
+
+    def to_s
+      @record[:name]
+    end
+  end
+
+  class Zones < Resource
+    def all
+      self.get.results.map{|record| Zone.new(concat_urls(url, record[:id]), record, **options)}
+    end
+
+    def find_by_name(name)
+      record = self.get(params: {name: name}).result
+
+      unless response.empty?
+        record = response.results.first
+
+        Zone.new(concat_urls(url, record[:id]), record, **options)
+      end
+    end
+
+    def find_by_id(id)
+      Zone.new(concat_urls(url, id), **options)
+    end
+  end
 end

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -139,8 +139,8 @@ module Cloudflare
       results.map{|record| FirewallRule.new(concat_urls(url, record[:id]), record, **options)}
     end
 
-    def firewalled_ips(mode)
-      firewall_rules(mode).all.collect {|r| r.record[:configuration][:value]}
+    def firewalled_ips(rules)
+      rules.collect {|r| r.record[:configuration][:value]}
     end
 
 

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -24,176 +24,176 @@
 require_relative 'connection'
 
 module Cloudflare
-  class Connection < Resource
-    def zones
-      @zones ||= Zones.new(concat_urls(url, 'zones'), options)
-    end
-  end
+	class Connection < Resource
+		def zones
+			@zones ||= Zones.new(concat_urls(url, 'zones'), options)
+		end
+	end
 
-  class DNSRecord < Resource
-    def initialize(url, record = nil, **options)
-      super(url, **options)
+	class DNSRecord < Resource
+		def initialize(url, record = nil, **options)
+			super(url, **options)
 
-      @record = record || self.get.result
-    end
+			@record = record || self.get.result
+		end
 
-    attr :record
+		attr :record
 
-    def to_s
-      "#{@record[:name]} #{@record[:type]} #{@record[:content]}"
-    end
-  end
+		def to_s
+			"#{@record[:name]} #{@record[:type]} #{@record[:content]}"
+		end
+	end
 
-  class DNSRecords < Resource
-    def initialize(url, zone, **options)
-      super(url, **options)
+	class DNSRecords < Resource
+		def initialize(url, zone, **options)
+			super(url, **options)
 
-      @zone = zone
-    end
+			@zone = zone
+		end
 
-    attr :zone
+		attr :zone
 
-    def all
-      # self.get.results.map{|record| DNSRecord.new(concat_urls(url, record[:id]), record, **options)}
-      dns_url = "?scope_type=organization"
-      page = 1
-      page_size = 100
-      results = []
+		def all
+			# self.get.results.map{|record| DNSRecord.new(concat_urls(url, record[:id]), record, **options)}
+			dns_url = "?scope_type=organization"
+			page = 1
+			page_size = 100
+			results = []
 
-      loop do  # fetch and aggregate all pages
-        rules = DNSRecords.new(concat_urls(url, "#{dns_url}&per_page=#{page_size}&page=#{page}"), self, **options)
-        results += rules.get.results
-        break if results.size % page_size != 0
-        page += 1
-      end
+			loop do  # fetch and aggregate all pages
+				rules = DNSRecords.new(concat_urls(url, "#{dns_url}&per_page=#{page_size}&page=#{page}"), self, **options)
+				results += rules.get.results
+				break if results.size % page_size != 0
+				page += 1
+			end
 
-      results.map{|record| DNSRecord.new(concat_urls(url, record[:id]), record, **options)}
+			results.map{|record| DNSRecord.new(concat_urls(url, record[:id]), record, **options)}
 
-    end
+		end
 
-    def find_by_name(name)
-      response = self.get(params: {name: name})
+		def find_by_name(name)
+			response = self.get(params: {name: name})
 
-      unless response.empty?
-        record = response.results.first
+			unless response.empty?
+				record = response.results.first
 
-        DNSRecord.new(concat_urls(url, record[:id]), record, **options)
-      end
-    end
+				DNSRecord.new(concat_urls(url, record[:id]), record, **options)
+			end
+		end
 
-    def find_by_id(id)
-      DNSRecord.new(concat_urls(url, id), **options)
-    end
-  end
+		def find_by_id(id)
+			DNSRecord.new(concat_urls(url, id), **options)
+		end
+	end
 
-  class FirewallRule < Resource
-    def initialize(url, record = nil, **options)
-      super(url, **options)
+	class FirewallRule < Resource
+		def initialize(url, record = nil, **options)
+			super(url, **options)
 
-      @record = record || self.get.result
-    end
+			@record = record || self.get.result
+		end
 
-    attr :record
+		attr :record
 
-    def to_s
-      "#{@record[:configuration][:value]} - #{@record[:mode]} - #{@record[:notes]}"
-    end
-  end
+		def to_s
+			"#{@record[:configuration][:value]} - #{@record[:mode]} - #{@record[:notes]}"
+		end
+	end
 
-  class FirewallRules < Resource
-    def initialize(url, zone, **options)
-      super(url, **options)
+	class FirewallRules < Resource
+		def initialize(url, zone, **options)
+			super(url, **options)
 
-      @zone = zone
-    end
+			@zone = zone
+		end
 
-    attr :zone
+		attr :zone
 
-    def all(mode = nil, ip = nil, notes = nil)
-      fw_url = "?scope_type=organization"
-      fw_url.concat("&mode=#{mode}") if mode
-      fw_url.concat("&configuration_value=#{ip}") if ip
-      fw_url.concat("&notes=#{notes}") if notes
-      page = 1
-      page_size = 100
-      results = []
+		def all(mode = nil, ip = nil, notes = nil)
+			fw_url = "?scope_type=organization"
+			fw_url.concat("&mode=#{mode}") if mode
+			fw_url.concat("&configuration_value=#{ip}") if ip
+			fw_url.concat("&notes=#{notes}") if notes
+			page = 1
+			page_size = 100
+			results = []
 
-      loop do  # fetch and aggregate all pages
-        rules = FirewallRules.new(concat_urls(url, "#{fw_url}&per_page=#{page_size}&page=#{page}"), self, **options)
-        results += rules.get.results
-        break if results.size % page_size != 0
-        page += 1
-      end
+			loop do  # fetch and aggregate all pages
+				rules = FirewallRules.new(concat_urls(url, "#{fw_url}&per_page=#{page_size}&page=#{page}"), self, **options)
+				results += rules.get.results
+				break if results.size % page_size != 0
+				page += 1
+			end
 
-      results.map{|record| FirewallRule.new(concat_urls(url, record[:id]), record, **options)}
-    end
+			results.map{|record| FirewallRule.new(concat_urls(url, record[:id]), record, **options)}
+		end
 
-    def firewalled_ips(rules)
-      rules.collect {|r| r.record[:configuration][:value]}
-    end
+		def firewalled_ips(rules)
+			rules.collect {|r| r.record[:configuration][:value]}
+		end
 
-    def blocked_ips
-      firewalled_ips(all("block"))
-    end
+		def blocked_ips
+			firewalled_ips(all("block"))
+		end
 
-    def set(mode, ip, note)
-      data = {"mode":"#{mode.to_s}","configuration":{"target":"ip","value":"#{ip}"},"notes":"cloudflare gem firewall_rules [#{mode}] #{note} #{Time.now.strftime("%m/%d/%y")} "}
-      post(data.to_json, content_type: 'application/json')
-    end
+		def set(mode, ip, note)
+			data = {"mode":"#{mode.to_s}","configuration":{"target":"ip","value":"#{ip}"},"notes":"cloudflare gem firewall_rules [#{mode}] #{note} #{Time.now.strftime("%m/%d/%y")} "}
+			post(data.to_json, content_type: 'application/json')
+		end
 
-    def unset(mode, value)
-      rule = send("find_by_#{mode}", value)
-      rule.delete
-    end
+		def unset(mode, value)
+			rule = send("find_by_#{mode}", value)
+			rule.delete
+		end
 
-    def find_by_id(id)
-      FirewallRule.new(concat_urls(url, id), **options)
-    end
+		def find_by_id(id)
+			FirewallRule.new(concat_urls(url, id), **options)
+		end
 
-    def find_by_ip(ip)
-      rule = FirewallRule.new(concat_urls(url, "?configuration_value=#{ip}"), **options)
-      FirewallRule.new(concat_urls(url, rule.record.first[:id]), **options)
-    end
-  end
+		def find_by_ip(ip)
+			rule = FirewallRule.new(concat_urls(url, "?configuration_value=#{ip}"), **options)
+			FirewallRule.new(concat_urls(url, rule.record.first[:id]), **options)
+		end
+	end
 
-  class Zone < Resource
-    def initialize(url, record = nil, **options)
-      super(url, **options)
-      @record = record || self.get.result
-    end
+	class Zone < Resource
+		def initialize(url, record = nil, **options)
+			super(url, **options)
+			@record = record || self.get.result
+		end
 
-    attr :record
+		attr :record
 
-    def dns_records
-      @dns_records ||= DNSRecords.new(concat_urls(url, 'dns_records'), self, **options)
-    end
+		def dns_records
+			@dns_records ||= DNSRecords.new(concat_urls(url, 'dns_records'), self, **options)
+		end
 
-    def firewall_rules
-      @firewall_rules ||= FirewallRules.new(concat_urls(url, "firewall/access_rules/rules"), self, **options)
-    end
+		def firewall_rules
+			@firewall_rules ||= FirewallRules.new(concat_urls(url, "firewall/access_rules/rules"), self, **options)
+		end
 
-    def to_s
-      @record[:name]
-    end
-  end
+		def to_s
+			@record[:name]
+		end
+	end
 
-  class Zones < Resource
-    def all
-      self.get.results.map{|record| Zone.new(concat_urls(url, record[:id]), record, **options)}
-    end
+	class Zones < Resource
+		def all
+			self.get.results.map{|record| Zone.new(concat_urls(url, record[:id]), record, **options)}
+		end
 
-    def find_by_name(name)
-      response = self.get(params: {name: name})
+		def find_by_name(name)
+			response = self.get(params: {name: name})
 
-      unless response.empty?
-        record = response.results.first
+			unless response.empty?
+				record = response.results.first
 
-        Zone.new(concat_urls(url, record[:id]), record, **options)
-      end
-    end
+				Zone.new(concat_urls(url, record[:id]), record, **options)
+			end
+		end
 
-    def find_by_id(id)
-      Zone.new(concat_urls(url, id), **options)
-    end
-  end
+		def find_by_id(id)
+			Zone.new(concat_urls(url, id), **options)
+		end
+	end
 end

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -169,7 +169,6 @@ module Cloudflare
     end
 
     def firewall_rules
-      # @firewall_rules ||= FirewallRules.new(concat_urls(url, "firewall/access_rules/rules?scope_type=organization"), self, **options)
       @firewall_rules ||= FirewallRules.new(concat_urls(url, "firewall/access_rules/rules"), self, **options)
     end
 

--- a/lib/cloudflare/zone.rb
+++ b/lib/cloudflare/zone.rb
@@ -94,7 +94,7 @@ module Cloudflare
 		end
 		
 		def find_by_name(name)
-			record = self.get(params: {name: name}).result
+			response = self.get(params: {name: name})
 			
 			unless response.empty?
 				record = response.results.first

--- a/spec/cloudflare/zone_spec.rb
+++ b/spec/cloudflare/zone_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe "Cloudflare DNS Zones" do
     let(:ip) {"123.123.123.123"}
     record = nil
 
+    it "should get all records" do
+        result = zone.dns_records.all
+
+        puts "===> #{result.size} records returned"
+        expect(result.size).to be > 0
+    end
+
+
     it "should create dns record" do
       response = zone.dns_records.post({
         type: "A",
@@ -46,6 +54,13 @@ RSpec.describe "Cloudflare DNS Zones" do
     record = nil
     before do
       response = zone.firewall_rules.set('block', ip2, notes)
+    end
+
+    it "should get all rules" do
+        result = zone.firewall_rules.all
+
+        puts "===> #{result.size} records returned"
+        expect(result.size).to be > 0
     end
 
     it "should create firewall rules for 'block', 'challenge', 'whitelist'" do

--- a/spec/cloudflare/zone_spec.rb
+++ b/spec/cloudflare/zone_spec.rb
@@ -27,16 +27,11 @@ RSpec.describe "Cloudflare DNS Zones" do
 
       result = response.result
       expect(result).to include(:id, :type, :name, :content, :ttl)
-      puts result.inspect
       record = result
     end
 
     it "should delete dns record" do
-      dns_records = zone.dns_records.all
-      expect(dns_records).to be_any
-      puts dns_records.first.inspect
       dns_record = zone.dns_records.find_by_id(record[:id])
-      puts dns_record
       response = dns_record.delete
       expect(response).to be_successful
     end

--- a/spec/cloudflare/zone_spec.rb
+++ b/spec/cloudflare/zone_spec.rb
@@ -1,41 +1,66 @@
 
 RSpec.describe "Cloudflare DNS Zones" do
-	include_context Cloudflare::RSpec::Connection
-	
-	it "should list zones" do
-		zones = connection.zones.all
-		
-		expect(zones).to be_any
-	end
-	
-	describe Cloudflare::DNSRecords, order: :defined do
-		let(:zone) {connection.zones.all.first}
-		let(:name) {"test"}
-		
-		it "should create dns record" do
-			response = zone.dns_records.post({
-				type: "A",
-				name: name,
-				content: "127.0.0.1",
-				ttl: 240,
-				proxied: false
-			}.to_json, content_type: 'application/json')
-			
-			expect(response).to be_successful
-			
-			result = response.result
-			expect(result).to include(:id, :type, :name, :content, :ttl)
-		end
-		
-		it "should delete dns record" do
-			dns_records = zone.dns_records.all
-			
-			expect(dns_records).to be_any
-			
-			dns_records.each do |record|
-				response = record.delete
-				expect(response).to be_successful
-			end
-		end
-	end
+  include_context Cloudflare::RSpec::Connection
+
+  it "should list zones" do
+    zones = connection.zones.all
+
+    expect(zones).to be_any
+  end
+
+  describe Cloudflare::DNSRecords, order: :defined do
+    let(:zone) {connection.zones.all.first}
+    let(:name) {"test"}
+
+    # it "should create dns record" do
+    # response = zone.dns_records.post({
+    # type: "A",
+    # name: name,
+    # content: "127.0.0.1",
+    # ttl: 240,
+    # proxied: false
+    # }.to_json, content_type: 'application/json')
+
+    # expect(response).to be_successful
+
+    # result = response.result
+    # expect(result).to include(:id, :type, :name, :content, :ttl)
+    # end
+
+    # it "should delete dns record" do
+    # dns_records = zone.dns_records.all
+
+    # expect(dns_records).to be_any
+
+    # dns_records.each do |record|
+    # response = record.delete
+    # expect(response).to be_successful
+    # end
+    # end
+  end
+
+  describe Cloudflare::FirewallRules, order: :defined do
+    let(:zone) {connection.zones.all.first}
+    let(:name) {"test"}
+    record = nil
+
+    it "should create firewall rules" do
+
+      ['block', 'challenge', 'whitelist'].each do |mode|
+        response = zone.firewall_rules.set(mode,'123.123.123.123', "gemtest")
+        expect(response).to be_successful
+
+        result = response.result
+        expect(result).to include(:id, :mode, :notes, :configuration)
+        expect(result[:mode]).to eq mode
+        record = result
+      end
+      puts record.inspect
+    end
+    it "should delete firewall rule" do
+      response = zone.firewall_rules.unset(record)
+
+      expect(response).to be_successful
+    end
+  end
 end


### PR DESCRIPTION
This is a PR for the forked version. Comment copied from base PR:

Added firewall rules.NOTE: in order to override the default 20 record limit, a pagination scheme is used that deviates from the dns_records model. afaict dns_records could utilize paging as well. This PR handles that for firewall_rules only; if the scheme is viable, or when an alternative scheme is implemented, it can be migrated to dns_records as well. If pagination is available in the original gem but I've just overlooked it, I'd suggest documentation.Another question is whether such methods as rule/record creation/deletion should be articulated methods in the gem, or just documented as leveraged resources. I left them out for now, but personally would be inclined to implement them within the gem.(I tried to restore the whitespace scheme of the original, but that was only partially successful, so there's a bunch of annoying whitespace diffs on blank lines.)



